### PR TITLE
 fix vk-blocks category that compatible with jobposting

### DIFF
--- a/inc/vk-blocks/vk-blocks-functions.php
+++ b/inc/vk-blocks/vk-blocks-functions.php
@@ -81,22 +81,27 @@ function vkblocks_blocks_assets() {
 add_action( 'init', 'vkblocks_blocks_assets' );
 
 // Add Block Category,
-function vkblocks_blocks_categories( $categories, $post ) {
-	global $vk_blocks_prefix;
-	return array_merge(
-		$categories,
-		array(
+if ( ! function_exists( 'vkblocks_blocks_categories' ) ) {
+
+	function vkblocks_blocks_categories( $categories, $post ) {
+		global $vk_blocks_prefix;
+
+		return array_merge(
+			$categories,
 			array(
-				'slug'  => 'vk-blocks-cat',
-				'title' => $vk_blocks_prefix . __( 'Blocks（Beta）', 'vk-blocks' ),
-				'icon'  => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M19 13H5v-2h14v2z" /></svg>',
-			),
-			array(
-				'slug'  => 'vk-blocks-cat-layout',
-				'title' => $vk_blocks_prefix . __( 'Blocks Layout（Beta）', 'vk-blocks' ),
-				'icon'  => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M19 13H5v-2h14v2z" /></svg>',
-			),
-		)
-	);
+				array(
+					'slug'  => 'vk-blocks-cat',
+					'title' => $vk_blocks_prefix . __( 'Blocks（Beta）', 'vk-blocks' ),
+					'icon'  => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M19 13H5v-2h14v2z" /></svg>',
+				),
+				array(
+					'slug'  => 'vk-blocks-cat-layout',
+					'title' => $vk_blocks_prefix . __( 'Blocks Layout（Beta）', 'vk-blocks' ),
+					'icon'  => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M19 13H5v-2h14v2z" /></svg>',
+				),
+			)
+		);
+	}
+
+	add_filter( 'block_categories', 'vkblocks_blocks_categories', 10, 2 );
 }
-add_filter( 'block_categories', 'vkblocks_blocks_categories', 10, 2 );


### PR DESCRIPTION
JOBプラグインとカテゴリを登録する関数がコンフリクトしないように、`function_exists`で条件分岐を追加しました。

https://github.com/vektor-inc/vk-blocks/compare/develop...fix/add-category-compatable-with-job-posting?expand=1#diff-eaf5c2958d125cbec354bdb488e313b8R84