### PR TITLE
Close settings panels at default

### DIFF
--- a/src/heading/block.js
+++ b/src/heading/block.js
@@ -116,7 +116,10 @@ registerBlockType('vk-blocks/heading', {
                     <HeadingToolbar minLevel={2} maxLevel={5} selectedLevel={level} onChange={setTitleFontSize}/>
                 </BlockControls>
                 <InspectorControls>
-                    <PanelBody title={__('Style Settings', 'vk-blocks')}>
+                    <PanelBody
+                        title={__('Style Settings', 'vk-blocks')}
+                        initialOpen={false}
+                        >
                         <SelectControl
                             label={__('Heading style', 'vk-blocks')}
                             value={titleStyle}
@@ -137,7 +140,10 @@ registerBlockType('vk-blocks/heading', {
                             step={0.1}
                         />
                     </PanelBody>
-                    <PanelBody title={__('Heading Settings', 'vk-blocks')}>
+                    <PanelBody
+                        title={__('Heading Settings', 'vk-blocks')}
+                        initialOpen={false}
+                        >
                         <label>{__('Level', 'vk-blocks')}</label>
                         <HeadingToolbar minLevel={1} maxLevel={7} selectedLevel={level} onChange={setTitleFontSize}/>
                         <p>{__('Text Alignment')}</p>
@@ -172,7 +178,10 @@ registerBlockType('vk-blocks/heading', {
                             onChange={(value) => setAttributes({titleColor: value})}
                         />
                     </PanelBody>
-                    <PanelBody title={__('Sub Text Settings', 'vk-blocks')}>
+                    <PanelBody
+                        title={__('Sub Text Settings', 'vk-blocks')}
+                        initialOpen={false}
+                        >
                         <RadioControl
                             label={__('Position', 'vk-blocks')}
                             selected={subTextFlag}

--- a/src/outer/block.js
+++ b/src/outer/block.js
@@ -80,7 +80,10 @@ registerBlockType('vk-blocks/outer', {
         return (
             <Fragment>
                 <InspectorControls>
-                    <PanelBody title={__('Background Setting', 'vk-blocks')}>
+                    <PanelBody
+						title={__('Background Setting', 'vk-blocks')}
+		                initialOpen={false}
+		                >
                         <BaseControl
                             label={__('Color Setting', 'vk-blocks')}
                             help={__('Color will overcome background image. If you want to display image, clear background color or set opacity 0.', 'vk-blocks')}
@@ -102,7 +105,6 @@ registerBlockType('vk-blocks/outer', {
                                 step={0.1}
                             />
                         </BaseControl>
-
                         <BaseControl
                             label={__('Background Image', 'vk-blocks')}
                             help=""
@@ -140,7 +142,10 @@ registerBlockType('vk-blocks/outer', {
                             />
                         </BaseControl>
                     </PanelBody>
-					<PanelBody title={__('Layout Setting', 'vk-blocks')}>
+					<PanelBody
+						title={__('Layout Setting', 'vk-blocks')}
+						initialOpen={false}
+						>
 						<BaseControl>
 							<RadioControl
 								label={__('Outer width', 'vk-blocks')}
@@ -180,7 +185,10 @@ registerBlockType('vk-blocks/outer', {
 							/>
 						</BaseControl>
 					</PanelBody>
-					<PanelBody title={__('Divider Setting', 'vk-blocks')}>
+					<PanelBody
+						title={__('Divider Setting', 'vk-blocks')}
+						initialOpen={false}
+						>
 						<BaseControl>
 							<SelectControl
 								label={__('Type', 'vk-blocks')}
@@ -239,7 +247,10 @@ registerBlockType('vk-blocks/outer', {
 							/>
 						</BaseControl>
 					</PanelBody>
-					<PanelBody title={__('Border Setting', 'vk-blocks')}>
+					<PanelBody
+						title={__('Border Setting', 'vk-blocks')}
+						initialOpen={false}
+						>
 						<BaseControl
 							// label={__('Border will disappear when divider effect is applied.', 'vk-blocks')}
 						>


### PR DESCRIPTION
### **Heading Block**
<img width="278" alt="スクリーンショット 2019-10-17 16 32 32" src="https://user-images.githubusercontent.com/8760841/66987620-18340d00-f0fc-11e9-8009-37a8afed2c2c.png">

### **Outer Block**
<img width="280" alt="スクリーンショット 2019-10-17 16 32 43" src="https://user-images.githubusercontent.com/8760841/66987628-1b2efd80-f0fc-11e9-9b69-71f43032a897.png">
