### PR TITLE
[ 開発環境 ] 10up/action-wordpress-plugin-deploy をコミットハッシュにピン留め

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
           name: dist
           path: dist/
       - name: WordPress Plugin Deploy
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
         env:
           BUILD_DIR: dist/${{ env.plugin_name }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
## 概要

`.github/workflows/release.yml` で使用している `10up/action-wordpress-plugin-deploy` のバージョン指定を `@stable` タグから特定のコミットハッシュ（v2.3.0: `54bd289b8525fd23a5c365ec369185f2966529c2`）にピン留めしました。

サプライチェーン攻撃対策として、タグは第三者によって書き換え可能であるため、不変であるコミットハッシュで固定することでセキュリティを向上させます。

Closes #147

## 確認手順

### 前提条件
- GitHub リポジトリへの push 権限があること

### 手順
1. このPRの差分を確認し、`.github/workflows/release.yml` の変更箇所を開く
   → `10up/action-wordpress-plugin-deploy@stable` が `10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0` に変更されていること
2. コメント `# v2.3.0` が行末に記載されていることを確認する
   → ピン留め元のバージョンが明確であること
3. コミットハッシュが正しいことを確認する: `gh api repos/10up/action-wordpress-plugin-deploy/git/ref/tags/2.3.0 --jq '.object.sha'` を実行する
   → `54bd289b8525fd23a5c365ec369185f2966529c2` が出力されること
4. （任意）テスト用にタグを作成してリリースワークフローが正常に動作することを確認する
   → WordPress.org へのデプロイステップが正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * 内部デプロイメントプロセスの安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->