### PR TITLE
[ 開発環境 ] burnett01/rsync-deployments をコミットハッシュにピン留め

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           name: dist
           path: dist/
       - name: Deploy test server [ Lightning ]
-        uses: burnett01/rsync-deployments@5.2.1
+        uses: burnett01/rsync-deployments@2651e3eecb4ea772cbe952695d04952e92027b4f # v5.2.1
         with:
           switches: -avzr --delete
           path: dist/${{ env.plugin_name }}/


### PR DESCRIPTION
## 概要

`.github/workflows/release.yml` で使用している `burnett01/rsync-deployments@5.2.1` をフルコミットハッシュ（`2651e3eecb4ea772cbe952695d04952e92027b4f`）にピン留めしました。

サプライチェーン攻撃対策として、タグ参照ではなくコミットハッシュで固定することで、タグの書き換えによる意図しないコード実行を防止します。

Closes #146

## 確認手順

### 前提条件
- GitHub Actions の実行権限があること

### 手順
1. このPRの「Files changed」タブを開く
   → `burnett01/rsync-deployments@5.2.1` が `burnett01/rsync-deployments@2651e3eecb4ea772cbe952695d04952e92027b4f # v5.2.1` に変更されていることを確認する
2. [burnett01/rsync-deployments の v5.2.1 タグ](https://github.com/burnett01/rsync-deployments/releases/tag/5.2.1) を開き、コミットハッシュが `2651e3eecb4ea772cbe952695d04952e92027b4f` であることを確認する
   → ハッシュが一致していることを確認する
3. リリースタグをpushして release ワークフローが正常に動作することを確認する（次回リリース時に確認）
   → Deploy to Test Server ステップが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * デプロイメント用GitHub Actionの参照を更新しました。テスト環境へのデプロイメントプロセスの安定性を向上させています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->